### PR TITLE
Test against Python 3.7

### DIFF
--- a/examples/requirements/test.txt
+++ b/examples/requirements/test.txt
@@ -5,6 +5,6 @@ py==1.4.31
 pytest-cov==2.2.1
 pytest-django==2.9.1
 pytest-ordering==0.5
-pytest==3.0.2
+pytest==3.0.7
 selenium==2.53.6
 tox==2.3.1

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
 #    py{27,34}-{django17,django18}
 #    py{34}-{django19}
     py{27,34,35,36}-{django18,django19,django110,django111}
+    py{37}-{django111}
 
 [testenv]
 envlogdir=


### PR DESCRIPTION
Very minor changes (only in test requirements) to get the tests to pass on Python 3.7 with Django 1.11