### PR TITLE
Upgrade django versions

### DIFF
--- a/examples/example/foo/models.py
+++ b/examples/example/foo/models.py
@@ -2,7 +2,7 @@ import datetime
 
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from six import python_2_unicode_compatible
 

--- a/examples/example/urls.py
+++ b/examples/example/urls.py
@@ -35,7 +35,7 @@ urlpatterns = [
     # url(r'^admin/doc/', include('django.contrib.admindocs.urls')),
 
     # Uncomment the next line to enable the admin:
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^admin/', admin.site.urls),
 
     # Sitemaps
     url(

--- a/examples/requirements/django_2_0.txt
+++ b/examples/requirements/django_2_0.txt
@@ -1,0 +1,8 @@
+-r common.txt
+-r test3.txt
+
+Django>=2.0,<2.1
+django-debug-toolbar==2.1
+django-debug-toolbar-force==0.1.7
+django-nine
+sqlparse==0.2.2

--- a/examples/requirements/django_2_1.txt
+++ b/examples/requirements/django_2_1.txt
@@ -1,0 +1,8 @@
+-r common.txt
+-r test3.txt
+
+Django>=2.1,<2.2
+django-debug-toolbar==2.1
+django-debug-toolbar-force==0.1.7
+django-nine
+sqlparse==0.2.2

--- a/examples/requirements/django_2_2.txt
+++ b/examples/requirements/django_2_2.txt
@@ -1,0 +1,8 @@
+-r common.txt
+-r test3.txt
+
+Django>=2.2,<3.0
+django-debug-toolbar==2.1
+django-debug-toolbar-force==0.1.7
+django-nine
+sqlparse==0.2.2

--- a/examples/requirements/test3.txt
+++ b/examples/requirements/test3.txt
@@ -1,0 +1,10 @@
+factory_boy==2.7.0
+fake-factory==0.7.2
+Faker==0.7.17
+py==1.8.0
+pytest-cov==2.8.1
+pytest-django==3.7.0
+pytest-ordering==0.6
+pytest==5.3.0
+selenium==2.53.6
+tox==2.3.1

--- a/src/qartez/sitemaps.py
+++ b/src/qartez/sitemaps.py
@@ -14,7 +14,7 @@ from .settings import (
     CHANGEFREQ
 )
 
-from nine import versions
+from django_nine import versions
 
 if versions.DJANGO_GTE_1_11:
     from django.urls import reverse_lazy

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,8 @@ envlist =
 #    py{27,34}-{django15,django16},
 #    py{27,34}-{django17,django18}
 #    py{34}-{django19}
-    py{27,34,35,36}-{django18,django19,django110,django111}
-    py{37}-{django111}
+    py{27,34,35,36}-django111
+    py37-django{111,20,21,22}
 
 [testenv]
 envlogdir=
@@ -17,10 +17,13 @@ deps =
 #    django15: -r{toxinidir}/examples/requirements/django_1_5.txt
 #    django16: -r{toxinidir}/examples/requirements/django_1_6.txt
 #    django17: -r{toxinidir}/examples/requirements/django_1_7.txt
-    django18: -r{toxinidir}/examples/requirements/django_1_8.txt
-    django19: -r{toxinidir}/examples/requirements/django_1_9.txt
-    django110: -r{toxinidir}/examples/requirements/django_1_10.txt
+#    django18: -r{toxinidir}/examples/requirements/django_1_8.txt
+#    django19: -r{toxinidir}/examples/requirements/django_1_9.txt
+#    django110: -r{toxinidir}/examples/requirements/django_1_10.txt
     django111: -r{toxinidir}/examples/requirements/django_1_11.txt
+    django20: -r{toxinidir}/examples/requirements/django_2_0.txt
+    django21: -r{toxinidir}/examples/requirements/django_2_1.txt
+    django22: -r{toxinidir}/examples/requirements/django_2_2.txt
 commands =
     {envpython} runtests.py
 #    {envpython} examples/example/manage.py test {posargs:qartez} --settings=settings --traceback -v 3


### PR DESCRIPTION
Hello,

It's time again for me to suggest an update to the project, for newer Django versions.

The actual changes suggested for this are only in testing -- a new requirements file for Python-3-only versions, some minor updates in the testing code itself (taking care of deprecation shims removed in Django 2.0), and new environment definitions.

This does drop support of testing on Django < 1.11, which are long-dead versions.

Included in a separate commit is an update to the use of django_nine -- in the interest of removing deprecation warnings altogether.

(This PR courtesy of [Matific](https://www.matific.com/), AKA [SlateScience](https://github.com/SlateScience/))

Thanks!